### PR TITLE
絵文字を検索できないバグを修正

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::SearchController < Api::V1::BaseController
+  skip_before_action :require_valid_token
+
   DEFAULT_PAGE_NUM = 10
   DEFAULT_ORDER = "new".freeze
 


### PR DESCRIPTION
close #41

access_tokenをつけなくても検索できるように