### PR TITLE
画像サイズをoriginalより大きくならないようにした

### DIFF
--- a/app/uploaders/emoji_uploader.rb
+++ b/app/uploaders/emoji_uploader.rb
@@ -2,15 +2,23 @@ class EmojiUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   version :large do
-    process resize_to_fill: [512, 512]
+    process create_square_version: 512
   end
 
-  version :thumb do
-    process resize_to_fill: [256, 256]
+  version :thumb, from_version: :large do
+    process resize_to_limit: [256, 256]
   end
 
-  version :slack do
-    process resize_to_fill: [128, 128]
+  version :slack, from_version: :large do
+    process resize_to_limit: [128, 128]
+  end
+
+  def create_square_version(max)
+    image = MiniMagick::Image.open(current_path)
+    width = image[:width]
+    height = image[:height]
+    length = [width, height, max].min
+    resize_to_fill(length, length)
   end
 
   def store_dir


### PR DESCRIPTION
close #138

## なぜ実装する必要があるのか、
* オリジナル画像サイズより大きな画像で保存するのは容量的にも処理的にも無駄が生じる
* 128px、64kB以下でないとslackにuploadできない

## どんな機能を実装した(したかった)のか
* 画像をオリジナル画像の短い辺、もしくは指定画像サイズの小さい方の正方形でくり抜くようにした。
* （未完）slack versionの容量を64kB以内に抑えたかった。

## どうやって実装した(したかった)のか
* uploader内でファイルサイズを調べて、トリミングするようにした。
* うまく容量制限内に圧縮する方法がみつからなかった。