### PR TITLE
同一のemojiで同じtag名をつけられないようにした

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
   belongs_to :emoji
   belongs_to :user
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: { scope: :emoji_id }
 end


### PR DESCRIPTION
close #159

# なぜ実装する必要があるのか、
* 同じemojiに同じ名前をタグを付けるのは意味がないから

# どんな機能を実装した(したかった)のか
* すでについているタグ名と同じタグ名をつけようとするとvalidation errorが起こる

# どうやって実装した(したかった)のか
* tag modeにscope付きのuniqueness validationを付与